### PR TITLE
feat: Add JaCoCo test coverage and GitHub Actions workflow for Spring…

### DIFF
--- a/.github/workflows/spring_rag_ci.yml
+++ b/.github/workflows/spring_rag_ci.yml
@@ -1,0 +1,33 @@
+name: Spring-RAG CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build, Test and Generate Coverage Report
+        run: mvn clean verify -f Spring-RAG/pom.xml
+
+      - name: Extract and Print Code Coverage
+        run: |
+          echo "Code Coverage for Spring-RAG:"
+          COVERAGE_FILE="Spring-RAG/target/site/jacoco/jacoco.csv"
+          if [ -f "$COVERAGE_FILE" ]; then
+            awk -F, 'NR == 2 { covered = $5; missed = $4; total = missed + covered; if (total > 0) printf "Instruction Coverage: %.2f%%\n", (covered / total) * 100; else print "Instruction Coverage: 0.00% (No instructions found/covered)"; }' "$COVERAGE_FILE"
+          else
+            echo "Coverage report not found at $COVERAGE_FILE. Check previous steps."
+            exit 1
+          fi

--- a/Spring-RAG/pom.xml
+++ b/Spring-RAG/pom.xml
@@ -93,6 +93,31 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+								<format>CSV</format>
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
…-RAG

Integrates JaCoCo for code coverage analysis within the Spring-RAG Maven project. Adds a GitHub Actions workflow (`.github/workflows/spring_rag_ci.yml`) that automates the following for the Spring-RAG project:
- Triggers on push/pull_request to the main branch.
- Sets up JDK 17.
- Builds, executes tests, and generates JaCoCo coverage reports (XML and CSV).
- Parses the JaCoCo CSV report and prints the instruction coverage percentage to the workflow log.

This provides a baseline for CI and code quality monitoring. Documentation on how to apply this to other projects in the repository has been provided separately.